### PR TITLE
Fix R CMD check warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     GGally (>= 1.0.0)
 Suggests:
   roxygen2 (>= 5.0.1),
-  testthat
+  testthat,
+  lintr
 Roxygen: list(wrap = FALSE)
 RoxygenNote: 5.0.1


### PR DESCRIPTION
This is caused by lintr not being in the Suggests, so I added it.

Alternatively you could remove the test-lintr.R file and `.lintr` files.